### PR TITLE
upgrade config to 0.32.1 & add Blackbox-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ is:
               __path__: /var/log/*log
               hostname: "{{ ansible_fqdn }}"
 
+## Blackbox (Website probes)
+
+Set `grafana_agent_enable_blackbox` to `true` and add the targets you want to
+be probed in `grafana_agent_blackbox_targets`, e.g:
+
+    grafana_agent_blackbox_targets:
+      - name: example
+        address: example.com
+        module: http_2xx
+
+The module must be a [blackbox module](https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md) defined in `grafana_agent_blackbox_module_config`.
+
+
 ## Postgres exporter
 
 Follow the [official documentation](https://github.com/prometheus-community/postgres_exporter#running-as-non-superuser)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,11 @@
 grafana_agent_prometheus_target: "https://prom-ship.example.org/api/v1/write"
 grafana_agent_prometheus_target_ssl: True
 
+grafana_agent_http_listen_address: 127.0.0.2
+grafana_agent_http_listen_port: 65534
+grafana_agent_grpc_listen_address: 127.0.0.2
+grafana_agent_grpc_listen_port: 65533
+
 grafana_agent_enable_nodeexporter: True
 grafana_agent_enable_nodeexporter_apt: False
 grafana_agent_enable_nodeexporter_ipmi: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,19 @@ grafana_agent_prometheus_nodeexporter_xfs: True
 grafana_agent_prometheus_nodeexporter_zfs: True
 grafana_agent_prometheus_nodeexporter_zoneinfo: False
 
+# Blackbox
+grafana_agent_enable_blackbox: False
+grafana_agent_blackbox_targets: []
+grafana_agent_blackbox_scrape_interval: 1m
+grafana_agent_blackbox_module_config:
+  - http_2xx:
+      prober: http
+  - http_post_2xx:
+      prober: http
+      http:
+        method: POST
+
+# PostgreSQL
 grafana_agent_enable_postgresexporter: False
 # grafana_agent_prometheus_postgresexporter_instance:
 grafana_agent_prometheus_postgresexporter_datasourcenames: []

--- a/templates/grafana-agent-env.j2
+++ b/templates/grafana-agent-env.j2
@@ -2,4 +2,4 @@ CONFIG_FILE=/etc/grafana-agent/config.yaml
 LOG_LEVEL=warn
 HOSTNAME={{ ansible_fqdn }}
 ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=go1.18
-CUSTOM_ARGS="-disable-reporting"
+CUSTOM_ARGS="-disable-reporting -server.http.address '{{ grafana_agent_http_listen_address }}:{{ grafana_agent_http_listen_port }}' -server.grpc.address '{{ grafana_agent_grpc_listen_address }}:{{ grafana_agent_grpc_listen_port }}'"

--- a/templates/grafana-agent.yaml.j2
+++ b/templates/grafana-agent.yaml.j2
@@ -173,6 +173,24 @@ integrations:
 {% endif %}
 {% if grafana_agent_prometheus_nodeexporter_zoneinfo %}      - zoneinfo
 {% endif %}
+
+{% if grafana_agent_enable_blackbox %}
+  blackbox:
+    enabled: true
+    scrape_interval: {{ grafana_agent_blackbox_scrape_interval }}
+    relabel_configs:
+      - target_label: instance
+        source_labels: [__param_target]
+    blackbox_targets:
+{% for target in grafana_agent_blackbox_targets %}      - name: {{ target.name | default(target.address) }}
+        address: {{ target.address }}
+        module: {{ target.module }}
+{% endfor %}
+    blackbox_config:
+      modules:
+        {{ grafana_agent_blackbox_modules_config | to_nice_yaml | indent(8) }}
+{% endif %}
+
 {% if grafana_agent_enable_postgresexporter %}
   postgres_exporter:
     enabled: true

--- a/templates/grafana-agent.yaml.j2
+++ b/templates/grafana-agent.yaml.j2
@@ -1,9 +1,3 @@
-server:
-  http_listen_port: 65534
-  http_listen_address: 127.0.0.2
-  grpc_listen_port: 65533
-  grpc_listen_address: 127.0.0.2
-
 metrics:
   global:
     scrape_interval: 1m


### PR DESCRIPTION
Some deprecated fields in the `server` block are removed in `v0.26.0`.
https://grafana.com/docs/agent/latest/upgrade-guide/#deprecation-on-yaml-fields-in-server-block-that-have-flags

This PR moves the options from the config to CLI options.